### PR TITLE
Remove 'System.Globalization.Invariant' from project file

### DIFF
--- a/src/server/server.csproj
+++ b/src/server/server.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
-  </ItemGroup> 
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.3.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />


### PR DESCRIPTION
This RuntimeHostConfigurationOption causes the SqlClient to crash on use